### PR TITLE
remove failing nightly python; add python 3.7 instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - "nightly"
 
 matrix:
   include:
   - python: 3.6
     env: mode=codestyle
-  allow_failures:
-  - python: "nightly"
+  - python: "3.7"
+    dist: xenial
+    sudo: false
 
 install:
   - if [[ ! -v mode ]]; then pip install -r requirements.txt; fi


### PR DESCRIPTION
The nightly build fails with some strange error. The following adds python 3.7.1 support on travis which should not fail (nightly is at 3.7.0a).