### PR TITLE
Support multiline CF values in create_ticket and edit_ticket.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ v1.0.11, unreleased
 - Tests: Update to new demo instance, fixing tests.
 - Tests: Disable tests in Travis, the existing test instance closed the REST interface (#28).
 - Fix support for custom field names containing colons (#37).
+- Fix support for custom field values containing newlines (#11).
 
 v1.0.10, 2017-02-22
 - PEP8 fixes


### PR DESCRIPTION
Introduce a new helper method __ticket_post_data that applies multi-value
and multi-line formatting to all ticket values.  In addition to fixing the
reported bug, this should help prevent situations where bad input to
create_ticket or edit_ticket leads to submitting a badly-formatted form to
the RT REST interface. Fixes issue #11.