### PR TITLE
The response content of resolving an already resolved ticket is an em…

### DIFF
--- a/rt/rt.py
+++ b/rt/rt.py
@@ -672,7 +672,10 @@ class Rt:
         """
         post_data = self.__ticket_post_data(kwargs)
         msg = self.__request('ticket/{}/edit'.format(str(ticket_id)), post_data={'content': post_data})
-        state = msg.split('\n')[2]
+        if msg.count('\n') > 1:
+            state = msg.split('\n')[2]
+        else:
+            state = msg
         return self.RE_PATTERNS['update_pattern'].match(state) is not None
 
     def get_history(self, ticket_id: typing.Union[str, int],


### PR DESCRIPTION
…pty string, doing msg.split('\n')[2] on which does not work, while the response is success with status code 200.