### PR TITLE
Handle possible empty responses in edit_ticket

### DIFF
--- a/rt/rt.py
+++ b/rt/rt.py
@@ -672,6 +672,8 @@ class Rt:
         """
         post_data = self.__ticket_post_data(kwargs)
         msg = self.__request('ticket/{}/edit'.format(str(ticket_id)), post_data={'content': post_data})
+        if "" == msg:  # Ticket not modified
+            return True
         state = msg.split('\n')[2]
         return self.RE_PATTERNS['update_pattern'].match(state) is not None
 


### PR DESCRIPTION
When a ticket is not modified, at least with RT 4.x, an empty response could be
returned.  Gracefully handle that as success.

For example given `tid` a possible `ticket id` in the RT queue and `tracker` an
`rt.Rt()` object, doing:

````
tracker.edit_ticket(tid, Subject=tracker.get_ticket(tid))
````

...and adding a `breakpoint()` just after the:

````
self.__request('ticket/{}/edit'.format(str(ticket_id)), post_data={'content': post_data})
````

line, then corresponding `msg` is an empty string, i.e.:

````
(Pdb) p msg
''
````

Thanks to @andreyyudin and discussed on pull request #47!