### PR TITLE
Add IS and IS NOT operators to search

### DIFF
--- a/rt/rt.py
+++ b/rt/rt.py
@@ -390,6 +390,8 @@ class Rt:
                              __lt       for operator <
                              __like     for operator LIKE
                              __notlike  for operator NOT LIKE
+                             __is       for operator IS
+                             __isnot    for operator IS NOT
 
                              Setting values to keywords constrain search
                              result to the tickets satisfying all of them.
@@ -411,7 +413,9 @@ class Rt:
                 'exact': '=',
                 'notexact': '!=',
                 'like': ' LIKE ',
-                'notlike': ' NOT LIKE '
+                'notlike': ' NOT LIKE ',
+                'is': ' IS ',
+                'isnot': ' IS NOT '
             }
 
             for key, value in kwargs.items():


### PR DESCRIPTION
The use case for `IS` and `IS NOT` operators is for comparing with NULL. For some reason I cannot not get `CF.{FieldName} != NULL` or `CF.{FIELDNAME} = NULL` , only with `IS` and `IS NOT` even though they seem to work with other values okay.