### PR TITLE
Cookie auth

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+v2.1.0, 2020-01-15
+- Add the possibility to provide cookies as dict to authenticate
+- Add 'Referer' header for CSRF check
+
 v2.0.1, 2020-08-07
 - Fix UnicodeDecodeError in logging code for non-text attachments (#50, #51)
 - Documentation: Add a search example (#49)

--- a/rt/rt.py
+++ b/rt/rt.py
@@ -104,6 +104,7 @@ class Rt:
     def __init__(self, url: str,
                  default_login: typing.Optional[str] = None,
                  default_password: typing.Optional[str] = None,
+                 cookies: typing.Optional[dict] = None,
                  proxy: typing.Optional[str] = None,
                  default_queue: str = DEFAULT_QUEUE,
                  skip_login: bool = False,
@@ -136,6 +137,11 @@ class Rt:
         self.default_queue = default_queue
         self.login_result = None
         self.session = requests.session()
+        if cookies:
+            self.session.headers.update({'referer': url})
+            self.session.cookies.update(cookies)
+            self.login_result = True
+
         self.session.verify = verify_cert
         if proxy is not None:
             if url.lower().startswith("https://"):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 
 setup(name='rt',
-      version='2.0.1',
+      version='2.1.0',
       description='Python interface to Request Tracker API',
       long_description=README,
       license='GNU General Public License (GPL)',


### PR DESCRIPTION
Quick support for cookie authentication, user must provide the cookie themselves in a dictionary in the kwarg cookies:
```
cookies = {"RT_SID_EXAMPLE.443": "valid session"}
tracker = rt.Rt(url='http://rt.example.com/REST/1.0/', cookies=cookies)
```
does not implement saving the existing session in to a file as requested in #18