### PR TITLE
Issue #11: Improve handling multiline responses

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+v2.1.1, 2021-03-23
+- Fix support for custom field values containing newlines in API responses (#10, #11)
+  (the previous change in v1.0.11 fixed API requests)
+
 v2.1.0, 2020-02-25
 - Add the possibility to provide cookies as dict to authenticate (#60)
 - Add 'Referer' header for CSRF check when cookies are used for authentication (#60)

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,7 @@ v2.1.1, 2021-03-23
 - Fix support for custom field values containing newlines in API responses (#10, #11)
   (the previous change in v1.0.11 fixed API requests)
 
-v2.1.0, 2020-02-25
+v2.1.0, 2021-02-25
 - Add the possibility to provide cookies as dict to authenticate (#60)
 - Add 'Referer' header for CSRF check when cookies are used for authentication (#60)
 - Add IS and IS NOT operators to search (#57)


### PR DESCRIPTION
The other pull request for this issue seems to have stalled, so I wanted to see if I could pick it up.

This branch takes another approach of adding a new method, `__parse_response_dict`, to more generally parse RT API response strings into Python dictionaries. It knows how to follow the general format of multiline fields in response strings, no matter what we're parsing.

The first commit in the request fixes the immediate issue reported in #11. Later commits reuse the new method in other places to help deduplicate code, and try to prevent this issue from popping up again in other methods.