### PR TITLE
Fix copy-pasted docs

### DIFF
--- a/rt/rest1.py
+++ b/rt/rest1.py
@@ -1423,7 +1423,7 @@ Content-Type: {}""".format(str(ticket_id), action, re.sub(r'\n', r'\n      ', te
     def take(self, ticket_id: typing.Union[str, int]) -> bool:
         """Take ticket.
 
-        :param ticket_id: ID of ticket to be merged
+        :param ticket_id: ID of ticket to be taken
         :returns: ``True``
                       Operation was successful
                   ``False``
@@ -1437,7 +1437,7 @@ Content-Type: {}""".format(str(ticket_id), action, re.sub(r'\n', r'\n      ', te
     def steal(self, ticket_id: typing.Union[str, int]) -> bool:
         """Steal ticket.
 
-        :param ticket_id: ID of ticket to be merged
+        :param ticket_id: ID of ticket to be stolen
         :returns: ``True``
                       Operation was successful
                   ``False``
@@ -1451,7 +1451,7 @@ Content-Type: {}""".format(str(ticket_id), action, re.sub(r'\n', r'\n      ', te
     def untake(self, ticket_id: typing.Union[str, int]) -> bool:
         """Untake ticket.
 
-        :param ticket_id: ID of ticket to be merged
+        :param ticket_id: ID of ticket to be untaken
         :returns: ``True``
                       Operation was successful
                   ``False``

--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -1551,7 +1551,7 @@ class Rt:
     def take(self, ticket_id: typing.Union[str, int]) -> bool:
         """Take ticket.
 
-        :param ticket_id: ID of ticket to be merged
+        :param ticket_id: ID of ticket to be taken
         :returns: ``True``
                       Operation was successful
                   ``False``
@@ -1571,7 +1571,7 @@ class Rt:
     def untake(self, ticket_id: typing.Union[str, int]) -> bool:
         """Untake ticket.
 
-        :param ticket_id: ID of ticket to be merged
+        :param ticket_id: ID of ticket to be untaken
         :returns: ``True``
                       Operation was successful
                   ``False``
@@ -1591,7 +1591,7 @@ class Rt:
     def steal(self, ticket_id: typing.Union[str, int]) -> bool:
         """Steal ticket.
 
-        :param ticket_id: ID of ticket to be merged
+        :param ticket_id: ID of ticket to be stolen
         :returns: ``True``
                       Operation was successful
                   ``False``
@@ -3248,7 +3248,7 @@ class AsyncRt:
     async def take(self, ticket_id: typing.Union[str, int]) -> bool:
         """Take ticket.
 
-        :param ticket_id: ID of ticket to be merged
+        :param ticket_id: ID of ticket to be taken
         :returns: ``True``
                       Operation was successful
                   ``False``
@@ -3268,7 +3268,7 @@ class AsyncRt:
     async def untake(self, ticket_id: typing.Union[str, int]) -> bool:
         """Untake ticket.
 
-        :param ticket_id: ID of ticket to be merged
+        :param ticket_id: ID of ticket to be untaken
         :returns: ``True``
                       Operation was successful
                   ``False``
@@ -3288,7 +3288,7 @@ class AsyncRt:
     async def steal(self, ticket_id: typing.Union[str, int]) -> bool:
         """Steal ticket.
 
-        :param ticket_id: ID of ticket to be merged
+        :param ticket_id: ID of ticket to be stolen
         :returns: ``True``
                       Operation was successful
                   ``False``


### PR DESCRIPTION
It seems that some of the docstrings were copy-pasted without change.
This PR fixes and and replaces the typo with correct information.