### PR TITLE
Add `query_format` to attachment search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.7.1], 2026-07-02
+### Added
+- Add a query_format parameter to sync/async get_attachments methods (#120 thanks @nazywam).
+
 ## [v3.7.0], 2026-06-29
 ### Removed
 - Remove support for now EoL Python 3.9.

--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -861,6 +861,7 @@ class Rt:
         self,
         ticket_id: typing.Union[str, int],
         query_filter: typing.Optional[list[dict[str, str]]] = None,
+        query_format: typing.Optional[typing.Union[str, list[str], dict[str, str]]] = None,
     ) -> typing.Sequence[dict[str, str]]:
         """Get attachment list for a given ticket.
 
@@ -881,6 +882,7 @@ class Rt:
 
         :param ticket_id: ID of ticket
         :param query_filter: JSON search filter, defaults to "filename is not empty"
+        :param query_format: Returned fields to be populated
         :returns: List of tuples for attachments belonging to given ticket.
                   Tuple format: (id, name, content_type, size)
                   Returns None if ticket does not exist.
@@ -890,10 +892,18 @@ class Rt:
         if query_filter is None:
             query_filter = [{'field': 'Filename', 'operator': 'IS NOT', 'value': ''}]
 
+        get_params = {'fields': 'Filename,ContentType,ContentLength'}
+        if isinstance(query_format, dict):
+            get_params = {**get_params, **query_format}
+        elif isinstance(query_format, list):
+            get_params['fields'] = ','.join(query_format)
+        elif isinstance(query_format, str):
+            get_params['fields'] = query_format
+
         for item in self.__paged_request(
             f'ticket/{ticket_id}/attachments',
             json_data=query_filter,
-            params={'fields': 'Filename,ContentType,ContentLength'},
+            params=get_params,
         ):
             attachments.append(item)
 
@@ -2567,6 +2577,7 @@ class AsyncRt:
         self,
         ticket_id: typing.Union[str, int],
         query_filter: typing.Optional[list[dict[str, str]]] = None,
+        query_format: typing.Optional[typing.Union[str, list[str], dict[str, str]]] = None,
     ) -> collections.abc.AsyncIterator[dict[str, typing.Any]]:
         """Get attachment list for a given ticket.
 
@@ -2587,15 +2598,24 @@ class AsyncRt:
 
         :param ticket_id: ID of ticket
         :param query_filter: JSON search filter, defaults to "filename is not empty"
+        :param query_format: Returned fields to be populated
         :returns: Iterator of attachments belonging to given ticket. collections.abc.AsyncIterator[typing.Dict[str, str]]
         """
         if query_filter is None:
             query_filter = [{'field': 'Filename', 'operator': 'IS NOT', 'value': ''}]
 
+        get_params = {'fields': 'Filename,ContentType,ContentLength'}
+        if isinstance(query_format, dict):
+            get_params = {**get_params, **query_format}
+        elif isinstance(query_format, list):
+            get_params['fields'] = ','.join(query_format)
+        elif isinstance(query_format, str):
+            get_params['fields'] = query_format
+
         async for item in self.__paged_request(
             f'ticket/{ticket_id}/attachments',
             json_data=query_filter,
-            params={'fields': 'Filename,ContentType,ContentLength'},
+            params=get_params,
         ):
             yield item
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -251,8 +251,7 @@ def test_attachments_create(rt_connection: rt.rest2.Rt):
         assert at_content == k.file_content
 
 
-@pytest.mark.asyncio
-async def test_attachments_search(rt_connection: rt.rest2.Rt):
+def test_attachments_search(rt_connection: rt.rest2.Rt):
     """Create a ticket with an attachments and verify that attachment search and filtering works correctly."""
     ticket_subject = f'Testing issue {random_string()}'
     ticket_text = (
@@ -263,16 +262,14 @@ async def test_attachments_search(rt_connection: rt.rest2.Rt):
     attachment_name = f'attachment-{random_string(length=10)}.txt'
     attachment = rt.rest2.Attachment(attachment_name, 'text/plain', attachment_content)
 
-    ticket_id = rt_connection.create_ticket(
-        subject=ticket_subject, content=ticket_text, queue=RT_QUEUE, attachments=[attachment]
-    )
+    ticket_id = rt_connection.create_ticket(subject=ticket_subject, content=ticket_text, queue=RT_QUEUE, attachments=[attachment])
 
-    at_list = [item for item in rt_connection.get_attachments(ticket_id, query_format=["TransactionId", "Headers"])]
+    at_list = [item for item in rt_connection.get_attachments(ticket_id, query_format=['TransactionId', 'Headers'])]
     assert at_list
     assert len(at_list) == 1
 
-    assert at_list[0]["TransactionId"]
-    assert at_list[0]["Headers"]
+    assert at_list[0]['TransactionId']
+    assert at_list[0]['Headers']
 
 
 def test_attachments_comment(rt_connection: rt.rest2.Rt):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -271,7 +271,7 @@ async def test_attachments_search(rt_connection: rt.rest2.Rt):
     assert at_list
     assert len(at_list) == 1
 
-    assert at_list[0]["TranscationId"]
+    assert at_list[0]["TransactionId"]
     assert at_list[0]["Headers"]
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -251,6 +251,30 @@ def test_attachments_create(rt_connection: rt.rest2.Rt):
         assert at_content == k.file_content
 
 
+@pytest.mark.asyncio
+async def test_attachments_search(rt_connection: rt.rest2.Rt):
+    """Create a ticket with an attachments and verify that attachment search and filtering works correctly."""
+    ticket_subject = f'Testing issue {random_string()}'
+    ticket_text = (
+        'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+    )
+
+    attachment_content = random_string(length=100).encode()
+    attachment_name = f'attachment-{random_string(length=10)}.txt'
+    attachment = rt.rest2.Attachment(attachment_name, 'text/plain', attachment_content)
+
+    ticket_id = rt_connection.create_ticket(
+        subject=ticket_subject, content=ticket_text, queue=RT_QUEUE, attachments=[attachment]
+    )
+
+    at_list = [item for item in rt_connection.get_attachments(ticket_id, query_format=["TransactionId", "Headers"])]
+    assert at_list
+    assert len(at_list) == 1
+
+    assert at_list[0]["TranscationId"]
+    assert at_list[0]["Headers"]
+
+
 def test_attachments_comment(rt_connection: rt.rest2.Rt):
     """Create a ticket and comment to it with a random (>= 2) number of attachments and verify that they have been successfully added to the ticket."""
     ticket_subject = f'Testing issue {random_string()}'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -20,7 +20,7 @@ __license__ = """ Copyright (C) 2013 CZ.NIC, z.s.p.o.
 """
 __docformat__ = 'reStructuredText en'
 __authors__ = [
-    '"Jiri Machalek" <jiri.machalek@nirt_connection.cz>',
+    '"Jiri Machalek" <jiri.machalek@nic.cz>',
     '"Georges Toth" <georges.toth@govcert.etat.lu>',
 ]
 

--- a/tests/test_basic_async.py
+++ b/tests/test_basic_async.py
@@ -275,12 +275,12 @@ async def test_attachments_search(async_rt_connection: rt.rest2.AsyncRt):
         subject=ticket_subject, content=ticket_text, queue=RT_QUEUE, attachments=[attachment]
     )
 
-    at_list = [item async for item in async_rt_connection.get_attachments(ticket_id, query_format=["TransactionId", "Headers"])]
+    at_list = [item async for item in async_rt_connection.get_attachments(ticket_id, query_format=['TransactionId', 'Headers'])]
     assert at_list
     assert len(at_list) == 1
 
-    assert at_list[0]["TransactionId"]
-    assert at_list[0]["Headers"]
+    assert at_list[0]['TransactionId']
+    assert at_list[0]['Headers']
 
 
 @pytest.mark.asyncio

--- a/tests/test_basic_async.py
+++ b/tests/test_basic_async.py
@@ -279,7 +279,7 @@ async def test_attachments_search(async_rt_connection: rt.rest2.AsyncRt):
     assert at_list
     assert len(at_list) == 1
 
-    assert at_list[0]["TranscationId"]
+    assert at_list[0]["TransactionId"]
     assert at_list[0]["Headers"]
 
 

--- a/tests/test_basic_async.py
+++ b/tests/test_basic_async.py
@@ -20,7 +20,7 @@ __license__ = """ Copyright (C) 2013 CZ.NIC, z.s.p.o.
 """
 __docformat__ = 'reStructuredText en'
 __authors__ = [
-    '"Jiri Machalek" <jiri.machalek@niasync_rt_connection.cz>',
+    '"Jiri Machalek" <jiri.machalek@nic.cz>',
     '"Georges Toth" <georges.toth@govcert.etat.lu>',
 ]
 
@@ -257,6 +257,30 @@ async def test_attachments_create(async_rt_connection: rt.rest2.AsyncRt):
         at_id = at_list[at_names.index(k.file_name)]['id']
         at_content = base64.b64decode((await async_rt_connection.get_attachment(at_id))['Content'])
         assert at_content == k.file_content
+
+
+@pytest.mark.asyncio
+async def test_attachments_search(async_rt_connection: rt.rest2.AsyncRt):
+    """Create a ticket with an attachments and verify that attachment search and filtering works correctly."""
+    ticket_subject = f'Testing issue {random_string()}'
+    ticket_text = (
+        'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+    )
+
+    attachment_content = random_string(length=100).encode()
+    attachment_name = f'attachment-{random_string(length=10)}.txt'
+    attachment = rt.rest2.Attachment(attachment_name, 'text/plain', attachment_content)
+
+    ticket_id = await async_rt_connection.create_ticket(
+        subject=ticket_subject, content=ticket_text, queue=RT_QUEUE, attachments=[attachment]
+    )
+
+    at_list = [item async for item in async_rt_connection.get_attachments(ticket_id, query_format=["TransactionId", "Headers"])]
+    assert at_list
+    assert len(at_list) == 1
+
+    assert at_list[0]["TranscationId"]
+    assert at_list[0]["Headers"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull requests adds a `query_format` parameter to sync/async `get_attachments` methods. Similar argument already exists for many other available methods like `search, get_ticket, get_asset`, etc.

Personally I'm using it to fetch the `TransactionId` for each attachment in order to find the attachments connected to the Create transaction.

Let me know if you'd like to see some new tests covering this addition