### PR TITLE
docs(rest2): search all queues

### DIFF
--- a/rt/rest2.py
+++ b/rt/rest2.py
@@ -472,8 +472,7 @@ class Rt:
             >>> tickets = list(tracker.search(queue='General', order='Status', raw_query="id='1'+OR+id='2'+OR+id='3'"))
 
         :param queue:      Queue where to search. If you wish to search across
-                           all of your queues, pass the ALL_QUEUES object as the
-                           argument.
+                           all of your queues, pass None as the argument.
         :param order:      Name of field sorting result list, for descending
                            order put - before the field name. E.g. -Created
                            will put the newest tickets at the beginning
@@ -2177,8 +2176,7 @@ class AsyncRt:
             >>> tickets = list(tracker.search(queue='General', order='Status', raw_query="id='1'+OR+id='2'+OR+id='3'"))
 
         :param queue:      Queue where to search. If you wish to search across
-                           all of your queues, pass the ALL_QUEUES object as the
-                           argument.
+                           all of your queues, pass None as the argument.
         :param order:      Name of field sorting result list, for descending
                            order put - before the field name. E.g. -Created
                            will put the newest tickets at the beginning


### PR DESCRIPTION
I could not find ALL_QUEUES in the rest2 API. In rest1, it is assigned to empty object. Apparently in rest2 we check against None instead: https://github.com/python-rt/python-rt/blob/5a9aaabd0214ab9db69d3b3cfaf992464a2da82f/rt/rest2.py#L523

This question has also been raised in https://github.com/python-rt/python-rt/issues/108